### PR TITLE
Add the rest of the parser productions

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -19,6 +19,26 @@ type Node interface {
 	End() token.Location
 }
 
+// SourceFile is a node representing a Go source file.
+type SourceFile struct {
+	comments
+	startLoc, endLoc token.Location
+	PackageName      Identifier
+	Imports          []ImportDecl
+	Declarations
+}
+
+func (n *SourceFile) Start() token.Location { return n.PackageName.Start() }
+func (n *SourceFile) End() token.Location {
+	if l := len(n.Declarations); l > 0 {
+		return n.Declarations[l-1].End()
+	}
+	if l := len(n.Imports); l > 0 {
+		return n.Imports[l-1].End()
+	}
+	return n.PackageName.End()
+}
+
 // A Statement is a node representing a statement.
 type Statement interface {
 	Node

--- a/ast/grammar.go
+++ b/ast/grammar.go
@@ -29,9 +29,30 @@ func Parse(p *Parser) (root Node, err error) {
 		}
 
 	}()
-	//	root = parseExpr(p)
-	root = parseDeclarations(p)
-	return
+	return parseSourceFile(p), nil
+}
+
+func parseSourceFile(p *Parser) Node {
+	p.expect(token.Package)
+	s := &SourceFile{comments: p.comments(), startLoc: p.lex.Start}
+	p.next()
+	s.PackageName = *parseIdentifier(p)
+	p.expect(token.Semicolon)
+	p.next()
+
+	for p.tok == token.Import {
+		s.Imports = append(s.Imports, *parseImportDecl(p))
+		p.expect(token.Semicolon)
+		p.next()
+	}
+	for p.tok != token.EOF {
+		decls := parseTopLevelDecl(p)
+		s.Declarations = append(s.Declarations, decls...)
+		p.expect(token.Semicolon)
+		p.next()
+	}
+	s.endLoc = p.lex.Start
+	return s
 }
 
 func parseStatement(p *Parser) Statement {

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -60,6 +60,29 @@ func sel(e Expression, ids ...*Identifier) Expression {
 	return p
 }
 
+func TestParseSourceFile(t *testing.T) {
+	parserTests{
+		{
+			`
+				package main
+				import "fmt"
+				func main() {}
+			`,
+			&SourceFile{
+				PackageName: *id("main"),
+				Imports: []ImportDecl{
+					{Imports: []ImportSpec{{Path: *strLit("fmt")}}},
+				},
+				Declarations: Declarations{
+					&FunctionDecl{
+						Name: *id("main"),
+					},
+				},
+			},
+		},
+	}.run(t, func(p *Parser) Node { return parseSourceFile(p) })
+}
+
 func TestParseImportDecl(t *testing.T) {
 	parserTests{
 		{


### PR DESCRIPTION
This adds the rest of the productions. Still needs more testing (I want to successfully parse all standard Go packages) and there are some bugs (semicolon optionalization is to loose) before the parser is done.
