### PR TITLE
Fix equality testing of AST nodes with big.Int and big.Rat fields.

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -781,10 +781,28 @@ type IntegerLiteral struct {
 	span
 }
 
+func (n *IntegerLiteral) Eq(v interface{}) bool {
+	m, ok := v.(*IntegerLiteral)
+	return ok && n.Value.Cmp(m.Value) == 0
+}
+
+func (n *IntegerLiteral) String() string {
+	return "IntegerLiteral{ " + n.Value.String() + " }"
+}
+
 // FloatLiteral is an expression node representing a floating point literal.
 type FloatLiteral struct {
 	Value *big.Rat
 	span
+}
+
+func (n *FloatLiteral) Eq(v interface{}) bool {
+	m, ok := v.(*FloatLiteral)
+	return ok && n.Value.Cmp(m.Value) == 0
+}
+
+func (n *FloatLiteral) String() string {
+	return "FloatLiteral{ " + n.Value.String() + " }"
 }
 
 // ImaginaryLiteral is an expression node representing an imaginary
@@ -792,6 +810,15 @@ type FloatLiteral struct {
 type ImaginaryLiteral struct {
 	Value *big.Rat
 	span
+}
+
+func (n *ImaginaryLiteral) Eq(v interface{}) bool {
+	m, ok := v.(*ImaginaryLiteral)
+	return ok && n.Value.Cmp(m.Value) == 0
+}
+
+func (n *ImaginaryLiteral) String() string {
+	return "ImaginaryLiteral{ " + n.Value.String() + " }"
 }
 
 // RuneLiteral is an expression node representing a rune literal.

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -2930,13 +2930,13 @@ func TestParseImaginaryLiteral(t *testing.T) {
 		return &ImaginaryLiteral{Value: &r}
 	}
 	parserTests{
-		{"0.i", i("0.0i")},
-		{"1.i", i("1.0i")},
-		{"1.0i", i("1.0i")},
-		{"0.1i", i("0.1i")},
-		{"0.1000i", i("0.1i")},
-		{"1e1i", i("10.0i")},
-		{"1e-1i", i("0.1i")},
+		{"0.i", i("0.0")},
+		{"1.i", i("1.0")},
+		{"1.0i", i("1.0")},
+		{"0.1i", i("0.1")},
+		{"0.1000i", i("0.1")},
+		{"1e1i", i("10.0")},
+		{"1e-1i", i("0.1")},
 	}.run(t, func(p *Parser) Node { return parseExpr(p) })
 }
 


### PR DESCRIPTION
This also requires github.com/eaburns/eq to be at least at commit eeeba96b29ead2cbc3fa1b4670538f2b57af34f.
