### PR TITLE
Rename MapType.Key and Value to KeyType and ValueType.

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -603,12 +603,12 @@ func (n *ChannelType) Loc() token.Location   { return n.Start() }
 
 // An MapType is a type node that represents a map from types to types.
 type MapType struct {
-	Key, Value Type
-	mapLoc     token.Location
+	KeyType, ValueType Type
+	mapLoc             token.Location
 }
 
 func (n *MapType) Start() token.Location { return n.mapLoc }
-func (n *MapType) End() token.Location   { return n.Value.End() }
+func (n *MapType) End() token.Location   { return n.ValueType.End() }
 func (n *MapType) Loc() token.Location   { return n.Start() }
 
 // An ArrayType is a type node that represents an array of types.

--- a/ast/check_test.go
+++ b/ast/check_test.go
@@ -134,7 +134,7 @@ func TestIsAssignable(t *testing.T) {
 		{nilLit, &StructType{}, false},
 		{nilLit, &Star{Target: t0}, true},
 		{nilLit, &SliceType{ElementType: t0}, true},
-		{nilLit, &MapType{Key: t0, Value: intType}, true},
+		{nilLit, &MapType{KeyType: t0, ValueType: intType}, true},
 		{nilLit, &ChannelType{ElementType: t0}, true},
 		{nilLit, &InterfaceType{}, true},
 		{bidirIntChan, &ChannelType{Send: true, ElementType: intType}, true},
@@ -353,18 +353,18 @@ func TestTypeIdentical(t *testing.T) {
 			false,
 		},
 		{
-			&MapType{Key: intType, Value: t1},
-			&MapType{Key: intType, Value: t1Ident},
+			&MapType{KeyType: intType, ValueType: t1},
+			&MapType{KeyType: intType, ValueType: t1Ident},
 			true,
 		},
 		{
-			&MapType{Key: intType, Value: t1},
-			&MapType{Key: intType, Value: t1Diff},
+			&MapType{KeyType: intType, ValueType: t1},
+			&MapType{KeyType: intType, ValueType: t1Diff},
 			false,
 		},
 		{
-			&MapType{Key: t0, Value: t1},
-			&MapType{Key: intType, Value: t1},
+			&MapType{KeyType: t0, ValueType: t1},
+			&MapType{KeyType: intType, ValueType: t1},
 			false,
 		},
 		{
@@ -940,8 +940,8 @@ func TestTypeUnderlying(t *testing.T) {
 			u: &ArrayType{Size: intLit("5"), ElementType: intType},
 		},
 		{
-			t: &MapType{Key: t0, Value: intType},
-			u: &MapType{Key: t0, Value: intType},
+			t: &MapType{KeyType: t0, ValueType: intType},
+			u: &MapType{KeyType: t0, ValueType: intType},
 		},
 		{
 			t: &ChannelType{Send: true, ElementType: intType},

--- a/ast/grammar.go
+++ b/ast/grammar.go
@@ -1359,10 +1359,10 @@ func parseMapType(p *Parser) Type {
 	p.next()
 	p.expect(token.OpenBracket)
 	p.next()
-	m.Key = parseType(p)
+	m.KeyType = parseType(p)
 	p.expect(token.CloseBracket)
 	p.next()
-	m.Value = parseType(p)
+	m.ValueType = parseType(p)
 	return m
 }
 

--- a/ast/type.go
+++ b/ast/type.go
@@ -231,7 +231,7 @@ func (t *ChannelType) Identical(other Type) bool {
 // Two map types are identical if they have identical key and value types.
 func (t *MapType) Identical(other Type) bool {
 	s, ok := other.(*MapType)
-	return ok && t.Key.Identical(s.Key) && t.Value.Identical(s.Value)
+	return ok && t.KeyType.Identical(s.KeyType) && t.ValueType.Identical(s.ValueType)
 }
 
 // Identical returns whether the two types are identical.


### PR DESCRIPTION
The names are longer, but they are more consistent with ElementType on
ChannelType, SliceType, and ArrayType.
